### PR TITLE
add filters and custom functions to extraction

### DIFF
--- a/Locale-TextDomain-OO-Extract-Xslate/t/10-kolon.t
+++ b/Locale-TextDomain-OO-Extract-Xslate/t/10-kolon.t
@@ -110,18 +110,18 @@ $expected = {
 		},
 		"Text with {variable}.\x{04}some context" => {
 			'reference' => {
-				't/data/kolon/custom.tx:18' => undef,
+				't/data/kolon/custom.tx:19' => undef,
 			}
 		},
 		"Text with umlauts: \x{e4}\x{f6}\x{fc}\x{df}." => {
 			'reference' => {
 				't/data/kolon/custom.tx:17' => undef,
-				't/data/kolon/custom.tx:16' => undef,
+				't/data/kolon/custom.tx:18' => undef,
 			}
 		},
 		'Book named \'Moby Dick\'.' => {
 			'reference' => {
-				't/data/kolon/custom.tx:13' => undef,
+				't/data/kolon/custom.tx:14' => undef,
 			}
 		},
 	},

--- a/Locale-TextDomain-OO-Extract-Xslate/t/10-kolon.t
+++ b/Locale-TextDomain-OO-Extract-Xslate/t/10-kolon.t
@@ -3,6 +3,7 @@
 
 use Locale::TextDomain::OO::Extract::Xslate;
 use Path::Tiny qw(path);
+use Data::Dumper;
 
 use Test::More;
 
@@ -11,7 +12,12 @@ my $expected = {
 		'Book named \'{title}\'.' => {
 			'reference' => {
 				't/data/kolon/functions.tx:10' => undef,
-				't/data/kolon/methods.tx:10' => undef
+				't/data/kolon/methods.tx:10' => undef,
+			}
+		},
+		'Book named \'Moby Dick\'.' => {
+			'reference' => {
+				't/data/kolon/filters.tx:13' => undef,
 			}
 		},
 		'' => {
@@ -23,43 +29,50 @@ my $expected = {
 		"Text with {variable}.\x{04}some context" => {
 			'reference' => {
 				't/data/kolon/methods.tx:15' => undef,
-				't/data/kolon/functions.tx:15' => undef
+				't/data/kolon/functions.tx:15' => undef,
 			}
 		},
 		'Page title' => {
 			'reference' => {
 				't/data/kolon/functions.tx:5' => undef,
-				't/data/kolon/methods.tx:5' => undef
+				't/data/kolon/methods.tx:5' => undef,
+				't/data/kolon/filters.tx:5' => undef,
 			}
 		},
 		'Just some text' => {
 			'reference' => {
 				't/data/kolon/functions.tx:2' => undef,
-				't/data/kolon/methods.tx:2' => undef
+				't/data/kolon/methods.tx:2' => undef,
+				't/data/kolon/filters.tx:2' => undef,
 			}
 		},
 		"Singular form with {variable1} and {variable2}.\x{00}Plural form with {variable1} and {variable2}!" => {
 			'reference' => {
 				't/data/kolon/methods.tx:17' => undef,
-				't/data/kolon/functions.tx:17' => undef
+				't/data/kolon/functions.tx:17' => undef,
 			}
 		},
 		"Text with umlauts: \x{e4}\x{f6}\x{fc}\x{df}." => {
 			'reference' => {
 				't/data/kolon/functions.tx:13' => undef,
-				't/data/kolon/methods.tx:13' => undef
+				't/data/kolon/methods.tx:13' => undef,
+				't/data/kolon/filters.tx:16' => undef,
 			}
 		},
 		"Singular form with {variable}.\x{00}Plural form with {variable}!\x{04}Whole other context" => {
 			'reference' => {
 				't/data/kolon/methods.tx:19' => undef,
-				't/data/kolon/functions.tx:19' => undef
+				't/data/kolon/functions.tx:19' => undef,
 			}
 		}
 	}
 };
 
-my @files = (qw( t/data/kolon/functions.tx t/data/kolon/methods.tx ));
+my @files = (qw(
+				t/data/kolon/functions.tx
+				t/data/kolon/methods.tx
+				t/data/kolon/filters.tx
+			));
 my $extract = Locale::TextDomain::OO::Extract::Xslate->new();
 
 for my $file ( map { path($_) } @files ) {
@@ -69,6 +82,62 @@ for my $file ( map { path($_) } @files ) {
 	$extract->extract;
 }
 
-is_deeply( $extract->lexicon_ref, $expected, "Succesful extraction from Kolon syntax templates" );
+my $got = $extract->lexicon_ref;
+is_deeply( $got, $expected, "Succesful extraction from Kolon syntax templates" )
+	or warn Dumper $got;
+
+
+# separate test for custom user-provided function names
+# with a couple of the original ones still in there just to check
+$extract = Locale::TextDomain::OO::Extract::Xslate->new();
+$expected = {
+	'i-default::' => {
+		'' => {
+			'msgstr' => {
+				'nplurals' => 2,
+				'plural' => 'n != 1'
+			}
+		},
+		'Page title' => {
+			'reference' => {
+				't/data/kolon/custom.tx:5' => undef,
+			}
+		},
+		'Just some text' => {
+			'reference' => {
+				't/data/kolon/custom.tx:2' => undef,
+			}
+		},
+		"Text with {variable}.\x{04}some context" => {
+			'reference' => {
+				't/data/kolon/custom.tx:18' => undef,
+			}
+		},
+		"Text with umlauts: \x{e4}\x{f6}\x{fc}\x{df}." => {
+			'reference' => {
+				't/data/kolon/custom.tx:17' => undef,
+				't/data/kolon/custom.tx:16' => undef,
+			}
+		},
+		'Book named \'Moby Dick\'.' => {
+			'reference' => {
+				't/data/kolon/custom.tx:13' => undef,
+			}
+		},
+	},
+};
+for my $file ( map { path($_) } 't/data/kolon/custom.tx' ) {
+	my $fn = $file->relative( q{./} )->stringify;
+	$extract->clear;
+	$extract->filename($fn);
+
+	# add out additional l10n functions
+	$extract->addl_l10n_function_re(qr{ loc | i10n_me | whatever }x);
+
+	$extract->extract;
+}
+my $got = $extract->lexicon_ref;
+is_deeply( $got, $expected, "Succesful extraction from Kolon syntax templates" )
+	or warn Dumper $got;
 
 done_testing;

--- a/Locale-TextDomain-OO-Extract-Xslate/t/data/kolon/custom.tx
+++ b/Locale-TextDomain-OO-Extract-Xslate/t/data/kolon/custom.tx
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+: "Just some text" | loc
+<html>
+  <head>
+    <title><: i10n_me("Page title") :></title>
+  </head>
+  <body>
+    <p>
+    <!-- filters with multiple arguments aren't supported yet in xslate, so we
+         only need to test the basic case
+    -->
+: for $books -> $book {
+      <em><: "Book named 'Moby Dick'." | loc :></em>
+      <br/>
+: }
+      <: i10n_me("Text with umlauts: äöüß.")  :>
+      <: "Text with umlauts: äöüß." | __ :>
+      <: __px("some context", "Text with {variable}.", variable => $param.variable) :>
+      <br/>
+    </p>
+  </body>
+</html>

--- a/Locale-TextDomain-OO-Extract-Xslate/t/data/kolon/custom.tx
+++ b/Locale-TextDomain-OO-Extract-Xslate/t/data/kolon/custom.tx
@@ -8,6 +8,7 @@
     <p>
     <!-- filters with multiple arguments aren't supported yet in xslate, so we
          only need to test the basic case
+         https://github.com/xslate/p5-Text-Xslate/issues/121
     -->
 : for $books -> $book {
       <em><: "Book named 'Moby Dick'." | loc :></em>

--- a/Locale-TextDomain-OO-Extract-Xslate/t/data/kolon/filters.tx
+++ b/Locale-TextDomain-OO-Extract-Xslate/t/data/kolon/filters.tx
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+: "Just some text" | __
+<html>
+  <head>
+    <title><: "Page title" | __ :></title>
+  </head>
+  <body>
+    <p>
+    <!-- filters with multiple arguments aren't supported yet in xslate, so we
+         only need to test the basic case
+    -->
+: for $books -> $book {
+      <em><: "Book named 'Moby Dick'." | __x :></em>
+      <br/>
+: }
+      <: "Text with umlauts: äöüß." | __ :>
+      <br/>
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
This MR adds the ability to extract translation strings when
the i10n function is used as a filter, like this:
    
        <: "whale" | __x :>
    
or to use custom l10n functions not in the default list, like this:
    
    $extract->addl_l10n_function_re(qr{ loc | i10n_me | whatever }x);

then

    <: "harpoon" | loc :>

