### PR TITLE
Handle __($foo)

### DIFF
--- a/Locale-TextDomain-OO-Extract-Xslate/lib/Locale/TextDomain/OO/Extract/Xslate.pm
+++ b/Locale-TextDomain-OO-Extract-Xslate/lib/Locale/TextDomain/OO/Extract/Xslate.pm
@@ -120,6 +120,7 @@ sub _walker {
 						&& ref($third) eq 'ARRAY'
 						&& $third->[0]
 						&& ref( $third->[0] ) eq 'Text::Xslate::Symbol'
+						&& $third->[0]->arity ne 'variable'
 					) {
 						my %msg = ( FILE => $FILENAME, LINE => $second->line, FLAGS => $flags, );
 						if ( _parseMsg( \%msg, $flags, $third ) ) {
@@ -128,6 +129,9 @@ sub _walker {
 						else {
 							warn "Invalid parameters for translation command at '$FILENAME', line " . $second->line;
 						}
+					}
+					elsif ($third->[0]->arity eq 'variable') {
+						next; # skip __($foo), nothing to do
 					}
 					else {
 						warn "Invalid parameters for translation command at '$FILENAME', line " . $second->line;
@@ -149,6 +153,7 @@ sub _walker {
 						&& ref($second) eq 'ARRAY'
 						&& $second->[0]
 						&& ref( $second->[0] ) eq 'Text::Xslate::Symbol'
+						&& $second->[0]->arity ne 'variable'
 					) {
 						my %msg = ( FILE => $FILENAME, LINE => $first->line, FLAGS => $flags, );
 						if ( _parseMsg( \%msg, $flags, $second ) ) {
@@ -157,6 +162,9 @@ sub _walker {
 						else {
 							warn "Invalid parameters for translation command at '$FILENAME', line " . $first->line;
 						}
+					}
+					elsif ($second->[0]->arity eq 'variable') {
+						next; # skip __($foo), nothing to do
 					}
 					else {
 						warn "Invalid parameters for translation command at '$FILENAME', line " . $first->line;

--- a/Locale-TextDomain-OO-Extract-Xslate/lib/Locale/TextDomain/OO/Extract/Xslate.pm
+++ b/Locale-TextDomain-OO-Extract-Xslate/lib/Locale/TextDomain/OO/Extract/Xslate.pm
@@ -120,7 +120,7 @@ sub _walker {
 						&& ref($third) eq 'ARRAY'
 						&& $third->[0]
 						&& ref( $third->[0] ) eq 'Text::Xslate::Symbol'
-						&& $third->[0]->arity ne 'variable'
+						&& $third->[0]->arity !~ /^(?: variable | methodcall | field )$/x
 					) {
 						my %msg = ( FILE => $FILENAME, LINE => $second->line, FLAGS => $flags, );
 						if ( _parseMsg( \%msg, $flags, $third ) ) {
@@ -130,8 +130,8 @@ sub _walker {
 							warn "Invalid parameters for translation command at '$FILENAME', line " . $second->line;
 						}
 					}
-					elsif ($third->[0]->arity eq 'variable') {
-						next; # skip __($foo), nothing to do
+					elsif ( $third->[0]->arity =~ /^(?: variable | methodcall | field )$/x ) {
+						next; # skip __($foo), __($foo.bar): nothing to do
 					}
 					else {
 						warn "Invalid parameters for translation command at '$FILENAME', line " . $second->line;
@@ -153,7 +153,7 @@ sub _walker {
 						&& ref($second) eq 'ARRAY'
 						&& $second->[0]
 						&& ref( $second->[0] ) eq 'Text::Xslate::Symbol'
-						&& $second->[0]->arity ne 'variable'
+						&& $second->[0]->arity !~ /^(?: variable | methodcall | field )$/x
 					) {
 						my %msg = ( FILE => $FILENAME, LINE => $first->line, FLAGS => $flags, );
 						if ( _parseMsg( \%msg, $flags, $second ) ) {
@@ -163,8 +163,8 @@ sub _walker {
 							warn "Invalid parameters for translation command at '$FILENAME', line " . $first->line;
 						}
 					}
-					elsif ($second->[0]->arity eq 'variable') {
-						next; # skip __($foo), nothing to do
+					elsif ( $second->[0]->arity =~ /^(?: variable | methodcall | field )$/x ) {
+						next; # skip __($foo), __($foo.bar): nothing to do
 					}
 					else {
 						warn "Invalid parameters for translation command at '$FILENAME', line " . $first->line;

--- a/Locale-TextDomain-OO-Extract-Xslate/t/10-kolon.t
+++ b/Locale-TextDomain-OO-Extract-Xslate/t/10-kolon.t
@@ -148,7 +148,7 @@ is_deeply( $got, $expected, "Succesful extraction from Kolon syntax templates wi
 {
 my @warnings;
 local $SIG{__WARN__} = sub { print STDERR @_; push @warnings, @_ };
-$extract = Locale::TextDomain::OO::Extract::Xslate->new();
+$extract = Locale::TextDomain::OO::Extract::Xslate->new(debug => 0);
 $expected = { };
 for my $file ( map { path($_) } 't/data/kolon/a_variable.tx' ) {
 	my $fn = $file->relative( q{./} )->stringify;

--- a/Locale-TextDomain-OO-Extract-Xslate/t/data/kolon/a_variable.tx
+++ b/Locale-TextDomain-OO-Extract-Xslate/t/data/kolon/a_variable.tx
@@ -1,0 +1,6 @@
+# a filter, a function, and a method
+# doing a separate file so I don't have to update the
+# expected line numbers in the existing test
+<: $a_variable | __ :>
+<: __($a_variable) :>
+<: $c.__($a_variable) :>

--- a/Locale-TextDomain-OO-Extract-Xslate/t/data/kolon/a_variable.tx
+++ b/Locale-TextDomain-OO-Extract-Xslate/t/data/kolon/a_variable.tx
@@ -1,6 +1,21 @@
-# a filter, a function, and a method
-# doing a separate file so I don't have to update the
-# expected line numbers in the existing test
+# A filter, a function, and a method.
+# Doing a separate file so I don't have to update the
+# expected line numbers in the existing tests
+#
+# None of these should warn or die or accumulate anything
+# in the extractor's lexicon.
+
+# variable
 <: $a_variable | __ :>
 <: __($a_variable) :>
 <: $c.__($a_variable) :>
+
+# methodcall
+<: $an_object.foo() | __ :>
+<: __($an_object.foo()) :>
+<: $c.__($an_object.foo()) :>
+
+# field
+<: $an_object.foo | __ :>
+<: __($an_object.foo) :>
+<: $c.__($an_object.foo) :>


### PR DESCRIPTION
Before this fix, putting __($foo) in your templates caused warnings:

    Invalid parameters for translation command at...

Yes, doing __($foo) might look silly, but there are cases where $foo is
already in the translation catalogue, and you just need to do the
lookup.