### PR TITLE
Handle "cascade with"

### DIFF
--- a/Locale-TextDomain-OO-Extract-Xslate/lib/Locale/TextDomain/OO/Extract/Xslate.pm
+++ b/Locale-TextDomain-OO-Extract-Xslate/lib/Locale/TextDomain/OO/Extract/Xslate.pm
@@ -108,6 +108,8 @@ sub _walker {
  
 	for my $sym (@{ $ast }) {
 
+		next if ref $sym eq 'ARRAY';
+
 		if ( $sym->arity eq 'methodcall' && $sym->value eq '.' ) {
 			my $second = $sym->second;
 			if ( $second && ref($second) eq 'Text::Xslate::Symbol' ) {

--- a/Locale-TextDomain-OO-Extract-Xslate/t/10-kolon.t
+++ b/Locale-TextDomain-OO-Extract-Xslate/t/10-kolon.t
@@ -131,7 +131,7 @@ for my $file ( map { path($_) } 't/data/kolon/custom.tx' ) {
 	$extract->clear;
 	$extract->filename($fn);
 
-	# add out additional l10n functions
+	# add our additional l10n functions
 	$extract->addl_l10n_function_re(qr{ loc | i10n_me | whatever }x);
 
 	$extract->extract;
@@ -139,5 +139,51 @@ for my $file ( map { path($_) } 't/data/kolon/custom.tx' ) {
 my $got = $extract->lexicon_ref;
 is_deeply( $got, $expected, "Succesful extraction from Kolon syntax templates with custom methods" )
 	or warn Dumper $got;
+
+
+# separate test for :cascade
+$extract = Locale::TextDomain::OO::Extract::Xslate->new();
+$expected = {
+	'i-default::' => {
+		'' => {
+			'msgstr' => {
+				'plural' => 'n != 1',
+				'nplurals' => 2
+			}
+		},
+		'The macro says: ' => {
+			'reference' => {
+				't/data/kolon/cascade/helpers.tx:1' => undef
+			}
+		},
+		'My Template!' => {
+			'reference' => {
+				't/data/kolon/cascade/base.tx:4' => undef
+			}
+		},
+		'My template body!' => {
+			'reference' => {
+				't/data/kolon/cascade/foo.tx:4' => undef
+			}
+		}
+	}
+};
+
+
+@files = (qw(
+	t/data/kolon/cascade/helpers.tx
+	t/data/kolon/cascade/base.tx
+	t/data/kolon/cascade/foo.tx
+));
+for my $file ( map { path($_) } @files ) {
+	my $fn = $file->relative( q{./} )->stringify;
+	$extract->clear;
+	$extract->filename($fn);
+	$extract->extract;
+}
+my $got = $extract->lexicon_ref;
+is_deeply( $got, $expected, "Succesful extraction from Kolon syntax templates with :cascade" )
+	or warn Dumper $got;
+
 
 done_testing;

--- a/Locale-TextDomain-OO-Extract-Xslate/t/data/kolon/cascade/base.tx
+++ b/Locale-TextDomain-OO-Extract-Xslate/t/data/kolon/cascade/base.tx
@@ -1,0 +1,7 @@
+: cascade with cascade::helpers
+
+: block title -> { # with default
+	[title: <: __('My Template!') :>]
+: }
+
+: block body -> { } # without default

--- a/Locale-TextDomain-OO-Extract-Xslate/t/data/kolon/cascade/foo.tx
+++ b/Locale-TextDomain-OO-Extract-Xslate/t/data/kolon/cascade/foo.tx
@@ -1,0 +1,7 @@
+: cascade cascade::base
+: # uses default title
+: around body -> {
+	: __('My template body!')
+	xXx <: some_macro('hi') :> xXx
+: }
+

--- a/Locale-TextDomain-OO-Extract-Xslate/t/data/kolon/cascade/helpers.tx
+++ b/Locale-TextDomain-OO-Extract-Xslate/t/data/kolon/cascade/helpers.tx
@@ -1,0 +1,2 @@
+<: macro some_macro -> ($s) { :>... <: __('The macro says: ') ~ $s :> ... <: } :>
+


### PR DESCRIPTION
In the case of this in a template:

   cascade with cascade::helpers

The $sym->second is an arrayref: [ 'cascade', 'helpers' ], and
extraction throws this error after "$self->_walker( $sym->second )" is
called:

    Can't call method "arity" on unblessed reference
    at lib/Locale/TextDomain/OO/Extract/Xslate.pm line 111.