### PR TITLE
Handle 'nil' without warnings.

### DIFF
--- a/Locale-TextDomain-OO-Extract-Xslate/lib/Locale/TextDomain/OO/Extract/Xslate.pm
+++ b/Locale-TextDomain-OO-Extract-Xslate/lib/Locale/TextDomain/OO/Extract/Xslate.pm
@@ -135,9 +135,9 @@ sub _walker {
 				}
 			}
 		}
-		elsif ( $sym->arity eq 'call' && 
+		elsif ( $sym->arity eq 'call' && defined $sym->value &&
 				# __x("foo")             "foo" | __x
-				($sym->value eq '(' ) || $sym->value eq '(call)') {
+				($sym->value eq '(' or $sym->value eq '(call)')) {
 			my $first = $sym->first;
 			if ( $first && ref($first) eq 'Text::Xslate::Symbol' ) {
 				if (   $first->arity eq 'name'

--- a/Locale-TextDomain-OO-Extract-Xslate/t/10-kolon.t
+++ b/Locale-TextDomain-OO-Extract-Xslate/t/10-kolon.t
@@ -140,4 +140,24 @@ my $got = $extract->lexicon_ref;
 is_deeply( $got, $expected, "Succesful extraction from Kolon syntax templates with custom methods" )
 	or warn Dumper $got;
 
+
+# separate test for <: if $x = nil :> warning bug,
+{
+my @warnings;
+local $SIG{__WARN__} = sub { print STDERR @_; push @warnings, @_ };
+$extract = Locale::TextDomain::OO::Extract::Xslate->new(debug => 0);
+$expected = { };
+for my $file ( map { path($_) } 't/data/kolon/nil.tx' ) {
+	my $fn = $file->relative( q{./} )->stringify;
+	$extract->clear;
+	$extract->filename($fn);
+	$extract->extract;
+}
+my $got = $extract->lexicon_ref;
+is_deeply( $got, $expected, "Succesful extraction from Kolon syntax templates with nil" )
+	or warn Dumper $got;
+	is scalar @warnings, 0, "No warnings from 'nil'"
+		or warn "warnings: @warnings";
+}
+
 done_testing;

--- a/Locale-TextDomain-OO-Extract-Xslate/t/data/kolon/nil.tx
+++ b/Locale-TextDomain-OO-Extract-Xslate/t/data/kolon/nil.tx
@@ -1,0 +1,4 @@
+# This should just extract without warnings 
+<: if ($max != nil) { :>
+     max="<: $max :>"
+<: } :>


### PR DESCRIPTION
The code was generating this warning:

    Use of uninitialized value in string eq
    at lib/Locale/TextDomain/OO/Extract/Xslate.pm line 138.

While fixing that with a defined check, I noticed the conditional there
needed the parentheses tweaked. It was originally written as

    if ($arity eq 'call' && ($value eq '(') || $value eq '(call)' )

or

    if ($x && $y || $z)

which because of operator precedence is really

    if ( ($x && $y) || $z)

and I think the intent was to do actually

    if ( $x && ($y || $z) )

so I added the parentheses to actually do that, which was necessary for
the defined() check I added to work.